### PR TITLE
Add systemd service and install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ This utility allows you to re-map these actions via evedev/uinput so that they c
 For more hardware-details, have a look at the [official Windows specification page][windows-spec].
 
 [windows-spec]: https://docs.microsoft.com/en-us/windows-hardware/design/component-guidelines/windows-pen-designs#bluetooth-button-implimentation
+
+### Install
+
+To install it you need cargo.
+
+Clone the repository and open it. Then run `cargo build --release`  and copy the binary file to /usr/bin/ via `sudo cp ./target/release/surface-pen-button /usr/bin/` . Now you can start it via `sudo surface-pen-button`.
+
+If you want to install the systemd service which automatically starts on system startup and restarts when the Pen isn't connected until it's connected you have to copy the surface-pen-button.service file to /etc/systemd/system/ via `sudo cp surface-pen-button.service /etc/systemd/system/`. Then you have to run `sudo systemctl daemon-reload` and then to enable it at system startup `sudo systemctl enable --now surface-pen-button.service`.

--- a/surface-pen-button.service
+++ b/surface-pen-button.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Surface Pen Bluetooth Button Mapping
+
+[Service]
+ExecStart=/usr/bin/surface-pen-button
+Restart=always
+RestartSec=2
+StartLimitIntervalSec=1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds a systemd service which can start automatically on system startup and restarts when the Pen isn't connected until it's connected. It also adds a small install guide.